### PR TITLE
Fixes #9 - Error: undefined method `[]' for true:TrueClass

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,15 @@ pagination:
 Note: this will only change the defaults. A page's YAML front-matter will
 override these defaults.
 
+### Remove Octopress pagination defaults
+
+If you had previously installed and configured Octopress as described at [Initial setup](http://octopress.org/docs/setup/) section you end up with a `_config.yml` which contains the two lines:
+
+    paginate: 10          # Posts per page on the blog index
+    paginate_path: "posts/:num"  # Directory base for pagination URLs eg. /posts/2/
+
+If you use the `paginate` key in a page's YAML front-matter you should have to remove the two lines in order to avoid [strange behaviour](https://github.com/octopress/paginate/issues/9).
+
 ### Pagination permalinks
 
 Assume your pagination template page was at `/index.html`. The second pagination page would be 


### PR DESCRIPTION
PROBLEM

The instructions given for the [Usage](https://github.com/octopress/paginate#usage) page doesn't work after Octopress [Initial setup](http://octopress.org/docs/setup/).

CAUSE

Configuring Octopress as described at [Initial setup](http://octopress.org/docs/setup/) leads to a `_config.yml` which contains the two lines:

```
paginate: 10          # Posts per page on the blog index
paginate_path: "posts/:num"  # Directory base for pagination URLs eg. /posts/2/
```

these two keys conflict in some way with the configuration ones used by this plugin.

SOLUTION

I've added the subsection `Remove Octopress pagination defaults` in which is suggested to remove the two lines.

octopress/paginate#9
