### PR TITLE
Added a reverse capability

### DIFF
--- a/lib/octopress-paginate.rb
+++ b/lib/octopress-paginate.rb
@@ -13,6 +13,7 @@ module Octopress
       'permalink'    => '/page:num/',
       'title_suffix' => ' - page :num',
       'page_num'     => 1
+      'reversed'     => false
     }
 
     LOOP = /(paginate.+\s+in)\s+(site\.(.+?))(.+)%}/
@@ -137,6 +138,10 @@ module Octopress
         end
       else
         page.site.collections[page['paginate']['collection']].docs
+      end
+      
+      if page['paginate']['reversed'] == true
+        collection = collection.reverse
       end
 
       if categories = page.data['paginate']['categories']

--- a/lib/octopress-paginate.rb
+++ b/lib/octopress-paginate.rb
@@ -12,7 +12,7 @@ module Octopress
       'limit'        => 5,
       'permalink'    => '/page:num/',
       'title_suffix' => ' - page :num',
-      'page_num'     => 1
+      'page_num'     => 1,
       'reversed'     => false
     }
 


### PR DESCRIPTION
Added a way to reverse your entire collection on a per page basis. Why would anyone do that? I'm making a gallery with files similar to `001-painting.md`, `002-painting.md`. When adding to the collection I don't want to have to rename every file again just to add one to the front.

More context: https://github.com/octopress/paginate/issues/11
