### PR TITLE
Add rudimentary support for tags on collections

### DIFF
--- a/lib/octopress-paginate.rb
+++ b/lib/octopress-paginate.rb
@@ -146,6 +146,10 @@ module Octopress
       if tags = page.data['paginate']['tags']
         collection = collection.reject{|p| (p.tags & tags).empty?}
       end
+      
+      if collection_tag = page.data['paginate']['collection_tag']
+        collection = collection.reject{|p| (not p.data['tags'].include? collection_tag)}
+      end
 
       collection
     end


### PR DESCRIPTION
This is a little bit hacky, because Jekyll doesn't actually have tags on
collections, but we can fake it for the purposes of pagination.

Usage:
1. Add a property called 'tags' to the documents in the collection.
2. Use the 'collection_tag' property in paginator to filter on one tag
from the list.

Note that it just does string matching for now, rather than actually
converting the tags on the collection documents to an array or anything
sensible like that.
