### PR TITLE
added sort and sort_direction parameters

### DIFF
--- a/lib/octopress-paginate.rb
+++ b/lib/octopress-paginate.rb
@@ -10,6 +10,8 @@ module Octopress
       'collection'   => 'posts',
       'per_page'     => 10,
       'limit'        => 5,
+      'sort'         => 'name',
+      'sort_direction' => 'ASC',
       'permalink'    => '/page:num/',
       'title_suffix' => ' - page :num',
       'page_num'     => 1
@@ -146,7 +148,20 @@ module Octopress
       if tags = page.data['paginate']['tags']
         collection = collection.reject{|p| (p.tags & tags).empty?}
       end
-
+      
+      # sort by basename of doccument
+      if page.data['paginate']['sort'].to_s == 'name'
+        collection = collection.sort! { |a,b| a.basename <=> b.basename }
+      # sort by attribute
+      else
+        key = page.data['paginate']['sort'].to_s
+        collection = collection.sort! { |a,b| a.data[key] <=> b.data[key] }
+      end
+      
+      # sort desc
+      if page.data['paginate']['sort_direction'].to_s.upcase == 'DESC'
+        collection = collection.reverse
+      end
       collection
     end
 

--- a/lib/octopress-paginate.rb
+++ b/lib/octopress-paginate.rb
@@ -151,7 +151,11 @@ module Octopress
       
       # sort by basename of doccument
       if page.data['paginate']['sort'].to_s == 'name'
-        collection = collection.sort! { |a,b| a.basename <=> b.basename }
+        if collection.first.respond_to?(:basename)
+          collection = collection.sort! { |a,b| a.basename <=> b.basename }
+        elsif collection.first.respond_to?(:name)
+          collection = collection.sort! { |a,b| a.name <=> b.name }
+        end
       # sort by attribute
       else
         key = page.data['paginate']['sort'].to_s


### PR DESCRIPTION
Within the config of pagination you can set sort by "name", which represents the basename of the document and any other attributes of the document (for example "title").
You can also set "sort_direction" with "DESC" if you want to reverse the results.

Default params, which can be overwritten in the config of each pagination (works also for collections):
'sort'         => 'name',
'sort_direction' => 'ASC',
