### PR TITLE
Fixes hook typo

### DIFF
--- a/lib/octopress-paginate.rb
+++ b/lib/octopress-paginate.rb
@@ -157,12 +157,15 @@ module Octopress
     def page_payload(payload, page)
       config = page.data['paginate']
       collection = collection(page)
+      collection_items = items(payload, collection)
       {
-        "#{config['collection']}"       => items(payload, collection),
+        "#{config['collection']}"       => collection_items,
+        "items"                         => collection_items,
         "page"                          => config['page_num'],
         "per_page"                      => config['per_page'],
         "limit"                         => config['limit'],
         "total_#{config['collection']}" => collection.size,
+        "total_items"                   => collection.size,
         "total_pages"                   => config['pages'],
         'previous_page'                 => config['previous_page'],
         'previous_page_path'            => config['previous_page_path'],

--- a/lib/octopress-paginate/hooks.rb
+++ b/lib/octopress-paginate/hooks.rb
@@ -6,7 +6,7 @@ module Octopress
           Octopress::Paginate.paginate(page)
         end
       end
-      Jekyll::Hooks.register :page, :pre_render do |page, payload|
+      Jekyll::Hooks.register :pages, :pre_render do |page, payload|
         if page.data['paginate']
           payload['paginator'] = Octopress::Paginate.page_payload(payload, page)
         end

--- a/octopress-paginate.gemspec
+++ b/octopress-paginate.gemspec
@@ -1,32 +1,48 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'octopress-paginate/version'
+# -*- encoding: utf-8 -*-
+# stub: octopress-paginate 1.1.2 ruby lib
 
-Gem::Specification.new do |spec|
-  spec.name          = "octopress-paginate"
-  spec.version       = Octopress::Paginate::VERSION
-  spec.authors       = ["Brandon Mathis"]
-  spec.email         = ["brandon@imathis.com"]
-  spec.summary       = %q{A nice and simple paginator for Jekyll sites.}
-  spec.homepage      = "https://github.com/octopress/paginate"
-  spec.license       = "MIT"
+Gem::Specification.new do |s|
+  s.name = "octopress-paginate"
+  s.version = "1.1.2"
 
-  spec.files         = `git ls-files -z`.split("\x0").grep(/^(bin\/|lib\/|assets\/|demo\/|changelog|readme|license)/i)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = ["lib"]
+  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib"]
+  s.authors = ["Brandon Mathis"]
+  s.date = "2016-04-24"
+  s.email = ["brandon@imathis.com"]
+  s.files = ["CHANGELOG.md", "LICENSE.txt", "README.md", "lib/octopress-paginate.rb", "lib/octopress-paginate/hooks.rb", "lib/octopress-paginate/version.rb"]
+  s.homepage = "https://github.com/octopress/paginate"
+  s.licenses = ["MIT"]
+  s.rubygems_version = "2.5.1"
+  s.summary = "A nice and simple paginator for Jekyll sites."
 
-  #spec.add_runtime_dependency "octopress-hooks"
-  spec.add_runtime_dependency "jekyll"
+  if s.respond_to? :specification_version then
+    s.specification_version = 4
 
-  spec.add_development_dependency "clash"
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "octopress-multilingual"
-  spec.add_development_dependency "octopress"
-
-  if RUBY_VERSION >= "2"
-    spec.add_development_dependency "octopress-debugger"
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_runtime_dependency(%q<jekyll>, [">= 0"])
+      s.add_development_dependency(%q<clash>, [">= 0"])
+      s.add_development_dependency(%q<bundler>, ["~> 1.7"])
+      s.add_development_dependency(%q<rake>, ["~> 10.0"])
+      s.add_development_dependency(%q<octopress-multilingual>, [">= 0"])
+      s.add_development_dependency(%q<octopress>, [">= 0"])
+      s.add_development_dependency(%q<octopress-debugger>, [">= 0"])
+    else
+      s.add_dependency(%q<jekyll>, [">= 0"])
+      s.add_dependency(%q<clash>, [">= 0"])
+      s.add_dependency(%q<bundler>, ["~> 1.7"])
+      s.add_dependency(%q<rake>, ["~> 10.0"])
+      s.add_dependency(%q<octopress-multilingual>, [">= 0"])
+      s.add_dependency(%q<octopress>, [">= 0"])
+      s.add_dependency(%q<octopress-debugger>, [">= 0"])
+    end
+  else
+    s.add_dependency(%q<jekyll>, [">= 0"])
+    s.add_dependency(%q<clash>, [">= 0"])
+    s.add_dependency(%q<bundler>, ["~> 1.7"])
+    s.add_dependency(%q<rake>, ["~> 10.0"])
+    s.add_dependency(%q<octopress-multilingual>, [">= 0"])
+    s.add_dependency(%q<octopress>, [">= 0"])
+    s.add_dependency(%q<octopress-debugger>, [">= 0"])
   end
 end


### PR DESCRIPTION
As per the [Jekyll docs on hooks](https://jekyllrb.com/docs/plugins/#hooks), `:page` isn't a valid container. This fixes it to be the correct `:pages`
