### PR TITLE
Added 'match all tags' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,15 +107,16 @@ Pagination is configured on a per-page basis under the `paginate` key in a page'
 
 ```yaml
 paginate:
-  collection:   posts
-  per_page:     10             # maximum number of items per page 
-  limit:        5              # Maximum number of pages to paginate (false for unlimited)
-  permalink:    /page:num/     # pagination path (relative to template page)
-  title_suffix: " - page :num" # Append to template's page title
-  category:     ''             # Paginate items in this category
-  categories:   []             # Paginate items in any of these categories
-  tag:          ''             # Paginate items tagged with this tag
-  tags:         []             # Paginate items tagged with any of these tags
+  collection:     posts
+  per_page:       10             # maximum number of items per page 
+  limit:          5              # Maximum number of pages to paginate (false for unlimited)
+  permalink:      /page:num/     # pagination path (relative to template page)
+  title_suffix:   " - page :num" # Append to template's page title
+  category:       ''             # Paginate items in this category
+  categories:     []             # Paginate items in any of these categories
+  tag:            ''             # Paginate items tagged with this tag
+  tags:           []             # Paginate items tagged with any of these tags
+  match_all_tags: ''             # Paginate items that contains ALL the tags specified in the 'tags' array
 ```
 
 Why set a pagination limit? For sites with lots of posts, this should speed up your build time considerably since Jekyll won't have to generate and write so many additional pages. Additionally, I suspect that it is very uncommon for users to browse paginated post indexes beyond a few pages. If you don't like it, it's easy to disable.

--- a/lib/octopress-paginate.rb
+++ b/lib/octopress-paginate.rb
@@ -7,12 +7,13 @@ module Octopress
     extend self
 
     DEFAULT = {
-      'collection'   => 'posts',
-      'per_page'     => 10,
-      'limit'        => 5,
-      'permalink'    => '/page:num/',
-      'title_suffix' => ' - page :num',
-      'page_num'     => 1
+      'collection'   	=> 'posts',
+      'per_page'     	=> 10,
+      'limit'        	=> 5,
+      'permalink'    	=> '/page:num/',
+      'title_suffix' 	=> ' - page :num',
+      'page_num'     	=> 1,
+      'match_all_tags'	=> nil
     }
 
     LOOP = /(paginate.+\s+in)\s+(site\.(.+?))(.+)%}/
@@ -144,9 +145,13 @@ module Octopress
       end
 
       if tags = page.data['paginate']['tags']
-        collection = collection.reject{|p| (p.tags & tags).empty?}
+        if page.data['paginate']['match_all_tags']
+          collection = collection.reject{|p| (tags - p.tags).any?}
+        else
+          collection = collection.reject{|p| (p.tags & tags).empty?}
+        end
       end
-
+      
       collection
     end
 


### PR DESCRIPTION
I added the possibility to paginate only items that contain ALL the tags specified in the 'tags' array.

You can do this adding:

``` yaml
paginate:
  match_all_tags: true
```
