### PR TITLE
Replace `posts.reverse` with `posts.docs.reverse` (deprecation)

### DIFF
--- a/lib/octopress-paginate.rb
+++ b/lib/octopress-paginate.rb
@@ -133,7 +133,7 @@ module Octopress
         if defined?(Octopress::Multilingual) && page.lang
           page.site.posts_by_language(page.lang)
         else
-          page.site.posts.reverse
+          page.site.posts.docs.reverse
         end
       else
         page.site.collections[page['paginate']['collection']].docs


### PR DESCRIPTION
Minor change––the `posts.reverse` method is deprecated, and should be replaced with `posts.docs.reverse`.

Serving my Jekyll site when using this paginate package, I get repeated (13 times) deprecated warnings:

```
Deprecation: posts.reverse should be changed to posts.docs.reverse.
                    Called by /Users/lukas/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/octopress-paginate-1.1.2/lib/octopress-paginate.rb:136:in `collection'.
```

Not a crisis by any means, but I can't find documentation of a compelling reason to continue using the deprecated method! Made the change to the only instance it's called to get rid of the eyesore.

Tested using my personal site; resolved the warnings, found no issues. Let me know if I should test more rigorously.

Also, let me know if this warrants any other changes (e.g. versioning).

Thanks!
