### PR TITLE
Support for paginating data collections.

### DIFF
--- a/lib/octopress-paginate.rb
+++ b/lib/octopress-paginate.rb
@@ -130,14 +130,19 @@ module Octopress
     end
 
     def collection(page)
-      collection = if page['paginate']['collection'] == 'posts'
+      name = page['paginate']['collection']
+      collection = if name == 'posts'
         if defined?(Octopress::Multilingual) && page.lang
           page.site.posts_by_language(page.lang)
         else
           page.site.posts.docs.reverse
         end
+      elsif page.site.collections.key? name
+        page.site.collections[name].docs
+      elsif page.site.data.key? name
+        page.site.data[name]
       else
-        page.site.collections[page['paginate']['collection']].docs
+        raise Exception, "Could not find collection or data with name: #{name}"
       end
       
       if page['paginate']['reversed'] == true


### PR DESCRIPTION
## Summary

This branch adds support for paginating collections defined in `site.data`, and raises an exception if the specified collection could not be found.

## Motivation

I've been relying on defining jekyll datasets in csv and yaml files. Since they are not actual collections and are instead defined in the _data directory, I would get an error when trying to paginate a data collection.

Now, you can define the data collection like this:

```yaml
title: Links
paginate:
  collection: links
  per_page: 10
```

and the collection will be paginated correctly.
