### PR TITLE
_config.yml: gems was deprecated in favour of plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ gem install octopress-paginate
 Then add the gem to your Jekyll configuration.
 
 ```ruby
-gems:
+plugins:
   - octopress-paginate
 ```
 

--- a/test/collection/_config.yml
+++ b/test/collection/_config.yml
@@ -1,5 +1,5 @@
 name: Test site
-gems:
+plugins:
   - octopress-paginate
 collections:
   - penguins

--- a/test/filter-category/_config.yml
+++ b/test/filter-category/_config.yml
@@ -1,5 +1,5 @@
 name: Test site
-gems:
+plugins:
   - octopress-paginate
 timezone: UTC
 markdown: redcarpet

--- a/test/limit/_config.yml
+++ b/test/limit/_config.yml
@@ -1,5 +1,5 @@
 name: Test site
-gems:
+plugins:
   - octopress-paginate
 timezone: UTC
 markdown: redcarpet

--- a/test/multilingual/_config.yml
+++ b/test/multilingual/_config.yml
@@ -1,6 +1,6 @@
 lang: en
 name: Test site
-gems:
+plugins:
   - octopress-paginate
   - octopress-multilingual
 timezone: UTC

--- a/test/no-limit/_config.yml
+++ b/test/no-limit/_config.yml
@@ -1,5 +1,5 @@
 name: Test site
-gems:
+plugins:
   - octopress-paginate
 timezone: UTC
 markdown: redcarpet

--- a/test/site-config/_config.yml
+++ b/test/site-config/_config.yml
@@ -1,5 +1,5 @@
 name: Test site
-gems:
+plugins:
   - octopress-paginate
 timezone: UTC
 markdown: redcarpet

--- a/test/standard/_config.yml
+++ b/test/standard/_config.yml
@@ -1,5 +1,5 @@
 name: Test site
-gems:
+plugins:
   - octopress-paginate
 timezone: UTC
 markdown: redcarpet


### PR DESCRIPTION
The `gems` key in _config.yml files was replaced by plugins on Jekyll 3.5. While it only triggers a Deprecation warning, the warning is visible during site compilation:

    Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.

This PR updates the docs to avoid new users to use the wrong key showing deprecation errors. The test cases have been updated as well to use the new keys on their _config.yml files so that deprecation warnings aren't logged to the terminal as well.