### PR TITLE
Fixes deprecation warning on categories and tags

### DIFF
--- a/lib/octopress-paginate.rb
+++ b/lib/octopress-paginate.rb
@@ -145,11 +145,11 @@ module Octopress
       end
 
       if categories = page.data['paginate']['categories']
-        collection = collection.reject{|p| (p.categories & categories).empty?}
+        collection = collection.reject{|p| (p['categories'] & categories).empty?}
       end
 
       if tags = page.data['paginate']['tags']
-        collection = collection.reject{|p| (p.tags & tags).empty?}
+        collection = collection.reject{|p| (p['tags'] & tags).empty?}
       end
 
       collection


### PR DESCRIPTION
A lot of noisy deprecations are being logged during site compilation when building a Jekyll site. I have been able to reproduce this for a few Jekyll versions. During compilation, the following message is logged several times per build:

    Deprecation: Called by ["/usr/local/rvm/gems/ruby-2.3.5/gems/jekyll-3.6.2/lib/jekyll/document.rb:374:in `method_missing'"].
    Deprecation: Document#tags is now a key in the #data hash.

It appears that the more pages in the main loop, the more times this message is logged. When serving a site using the --watch option, there are so many deprecation warnings that it makes hard to debug other issues with the site or to inspect the logs.

This PR fixes this behaviour by using the new syntax proposed in Jekyll to access the categories and the tags for a post, removing the deprecation messages.

I've successfully tested this to work by using the test suite provided with this gem and by using a patched version of octopress-paginate with this PR applied to build my site and in both cases the deprecation messages are gone. CI tests will still fail because the test suite has other unrelated errors.